### PR TITLE
Stop retaining container.

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -12,10 +12,11 @@ else
 fi
 
 echo "--- Building Pi Image"
-CONTINUE=1 PRESERVE_CONTAINER=1 ./build-docker.sh
+CONTINUE=1 ./build-docker.sh
 
 echo "--- Uploading artifacts"
 
+# Empty dist dir just to be sure we don't move more things than necessary
 rm -rf dist/*
 
 # Moving to another folder to match convention of other installers


### PR DESCRIPTION
No longer necessary, as the build only happens on occasion.
Fixes issue with `apt` dependencies being out of date.
Reverts changes added in 41370702f6f3cec44d99de3cab097726a4056c27